### PR TITLE
Feat(CourseItem): CourseItem 엔티티 추가(dayNo - "day_no"): n일차 정보 저장)

### DIFF
--- a/src/main/java/com/multi/travel/course/controller/CourseController.java
+++ b/src/main/java/com/multi/travel/course/controller/CourseController.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 /**
  * Please explain the class!!!
  *
@@ -86,6 +88,26 @@ public class CourseController {
         courseService.updateItemsOrder(courseId, dto.getItems());
         return ResponseEntity.noContent().build();
     }
+
+    /** 하루별 코스 아이템 조회 */
+    @GetMapping("/{courseId}/items")
+    public ResponseEntity<ResponseDto> getCourseItemsByDay(
+            @PathVariable Long courseId,
+            @RequestParam("day") Integer dayNo
+    ) {
+        List<CourseItemResDto> items = courseService.getCourseItemsByDay(courseId, dayNo);
+
+        if (items.isEmpty()) {
+            return ResponseEntity.ok(
+                    new ResponseDto(HttpStatus.OK, dayNo + "일차 코스가 비어 있습니다.", items)
+            );
+        }
+
+        return ResponseEntity.ok(
+                new ResponseDto(HttpStatus.OK, dayNo + "일차 코스 조회 성공", items)
+        );
+    }
+
 
     /** TODO: 특정 코스의 아이템 삭제 구현 필요 */
 

--- a/src/main/java/com/multi/travel/course/dto/CourseItemReqDto.java
+++ b/src/main/java/com/multi/travel/course/dto/CourseItemReqDto.java
@@ -19,4 +19,5 @@ public class CourseItemReqDto {
     private String placeType; // TOUR_SPOT or ACCOMMODATION
     private Long placeId; // 관광지/숙소의 ID
     private Integer orderNo; // 순서
+    private Integer dayNo;  // 몇 일차에 속하는지
 }

--- a/src/main/java/com/multi/travel/course/dto/CourseItemResDto.java
+++ b/src/main/java/com/multi/travel/course/dto/CourseItemResDto.java
@@ -19,4 +19,5 @@ public class CourseItemResDto {
     private String placeType;
     private Long placeId;
     private Integer orderNo;
+    private Integer dayNo;
 }

--- a/src/main/java/com/multi/travel/course/entity/CourseItem.java
+++ b/src/main/java/com/multi/travel/course/entity/CourseItem.java
@@ -37,6 +37,10 @@ public class CourseItem {
     @Column(name = "place_id", nullable = false)
     private Long placeId;
 
+    /** n일차 정보 */
+    @Column(name = "day_no", nullable = false)
+    private Integer dayNo;
+
     /** 순서 (사용자 드래그 순서 기준) */
     @Column(name = "order_no", nullable = false)
     private Integer orderNo;

--- a/src/main/java/com/multi/travel/course/repository/CourseItemRepository.java
+++ b/src/main/java/com/multi/travel/course/repository/CourseItemRepository.java
@@ -1,5 +1,6 @@
 package com.multi.travel.course.repository;
 
+import com.multi.travel.course.entity.Course;
 import com.multi.travel.course.entity.CourseItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,4 +14,6 @@ import java.util.List;
  * @since : 2025-11-08 토요일
  */
 public interface CourseItemRepository extends JpaRepository<CourseItem, Long> {
+    // 하루별 코스 조회용 쿼리 메서드
+    List<CourseItem> findByCourseAndDayNoOrderByOrderNoAsc(Course course, Integer dayNo);
 }

--- a/src/main/java/com/multi/travel/course/service/CourseService.java
+++ b/src/main/java/com/multi/travel/course/service/CourseService.java
@@ -66,6 +66,7 @@ public class CourseService {
                     .placeType(itemDto.getPlaceType())
                     .placeId(itemDto.getPlaceId())
                     .orderNo(itemDto.getOrderNo())
+                    .dayNo(itemDto.getDayNo())
                     .build();
             course.addItem(item);
         });
@@ -100,6 +101,7 @@ public class CourseService {
                 .placeType(dto.getPlaceType())
                 .placeId(dto.getPlaceId())
                 .orderNo(dto.getOrderNo())
+                .dayNo(dto.getDayNo())
                 .build();
 
         itemRepository.save(item);
@@ -116,6 +118,20 @@ public class CourseService {
             itemRepository.save(item);
         }
     }
+
+    /** 코스 하루별 조회 */
+    @Transactional(readOnly = true)
+    public List<CourseItemResDto> getCourseItemsByDay(Long courseId, Integer dayNo) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID(" + courseId + ")의 코스를 찾을 수 없습니다."));
+
+        List<CourseItem> items = itemRepository.findByCourseAndDayNoOrderByOrderNoAsc(course, dayNo);
+
+        return items.stream()
+                .map(this::mapToItemResDto)
+                .toList();
+    }
+
 
     /** TODO: 특정 코스의 아이템 삭제 구현 필요 */
 
@@ -149,6 +165,7 @@ public class CourseService {
                 .placeType(item.getPlaceType())
                 .placeId(item.getPlaceId())
                 .orderNo(item.getOrderNo())
+                .dayNo(item.getDayNo())
                 .build();
     }
 }


### PR DESCRIPTION
## 📎 관련 이슈
Closes #68 


## 📝 작업 내용
- CourseItem 엔티티에 `dayNo` 필드 추가
- 코스 생성/추가 시 `dayNo` 저장 로직 추가
- 하루별 코스 조회 API (`GET /courses/{courseId}/items?day={n}`) 구현
- DTO 및 매핑 로직 수정 (`mapToItemResDto`)

- Postman으로 `dayNo` 정상 저장/조회 확인
- 기존 순서 변경(`PUT /items/order`) 기능 정상 동작

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 💬 비고
