### PR TITLE
Feat(Course): 코스 편집 페이지 구현

### DIFF
--- a/src/main/java/com/multi/travel/ai/controller/AICourseViewController.java
+++ b/src/main/java/com/multi/travel/ai/controller/AICourseViewController.java
@@ -1,0 +1,33 @@
+package com.multi.travel.ai.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : AICourseViewController
+ * @since : 2025-11-12 수요일
+ */
+@Controller
+@RequiredArgsConstructor
+public class AICourseViewController {
+
+    /** AI 코스 결과 페이지 */
+    @GetMapping("/ai/courses/view/{planId}")
+    public String showAICourseView(@PathVariable Long planId, Model model) {
+        model.addAttribute("planId", planId);
+        return "ai/course-view"; // → 결과 페이지
+    }
+
+    /** 피드백 입력 페이지 */
+    @GetMapping("/ai/courses/feedback/{planId}")
+    public String showFeedbackPage(@PathVariable Long planId, Model model) {
+        model.addAttribute("planId", planId);
+        return "ai/course-feedback"; // → 피드백 입력 페이지
+    }
+}

--- a/src/main/java/com/multi/travel/course/controller/CourseController.java
+++ b/src/main/java/com/multi/travel/course/controller/CourseController.java
@@ -3,6 +3,7 @@ package com.multi.travel.course.controller;
 import com.multi.travel.common.ResponseDto;
 import com.multi.travel.course.dto.*;
 import com.multi.travel.course.service.CourseService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -142,4 +143,15 @@ public class CourseController {
         );
     }
 
+    /** 코스 전체 수정 (기존 아이템 삭제 후 재등록) */
+    @PutMapping("/{planId}")
+    public ResponseEntity<ResponseDto> updateCourse(
+            @PathVariable Long planId,
+            @Valid @RequestBody CourseReqDto dto
+    ) {
+        CourseResDto updated = courseService.updateCourse(planId, dto);
+        return ResponseEntity.ok(
+                new ResponseDto(HttpStatus.OK, "코스 수정 완료", updated)
+        );
+    }
 }

--- a/src/main/java/com/multi/travel/course/controller/CourseViewController.java
+++ b/src/main/java/com/multi/travel/course/controller/CourseViewController.java
@@ -1,0 +1,33 @@
+package com.multi.travel.course.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : seunga03
+ * @filename : CourseViewController
+ * @since : 2025-11-12 수요일
+ */
+@Controller
+@RequiredArgsConstructor
+public class CourseViewController {
+
+    /** 코스 수정 페이지 진입 - AI 생성 코스든 일반 코스든 동일하게 사용 */
+    @GetMapping("/courses/edit/{planId}")
+    public String editCoursePage(@PathVariable Long planId, Model model) {
+        model.addAttribute("planId", planId);
+        return "course/course-edit"; // templates/course/course-edit.html
+    }
+
+    /** 코스 생성 결과 확인용 (AI 생성 직후 뷰 페이지) */
+    @GetMapping("/courses/view/{planId}")
+    public String viewAICoursePage(@PathVariable Long planId, Model model) {
+        model.addAttribute("planId", planId);
+        return "course/course-view"; // 필요 시 별도 뷰
+    }
+}

--- a/src/main/java/com/multi/travel/course/dto/CourseItemReqDto.java
+++ b/src/main/java/com/multi/travel/course/dto/CourseItemReqDto.java
@@ -1,6 +1,11 @@
 package com.multi.travel.course.dto;
 
-import lombok.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * 코스에 들어갈 항목 오청 dto
@@ -16,8 +21,15 @@ import lombok.*;
 @NoArgsConstructor
 public class CourseItemReqDto {
 //    private Long courseId;
+    @NotBlank(message = "카테고리 코드는 필수입니다.")
     private String categoryCode; // 기존의 placeType을 카테고리 코드로 변경
+
+    @NotNull(message = "placeId는 필수입니다.")
     private Long placeId; // 관광지/숙소의 ID
+
+    @NotNull(message = "orderNo는 필수입니다.")
     private Integer orderNo; // 순서
+
+    @NotNull(message = "dayNo는 필수입니다.")
     private Integer dayNo;  // 몇 일차에 속하는지
 }

--- a/src/main/java/com/multi/travel/course/repository/CourseRepository.java
+++ b/src/main/java/com/multi/travel/course/repository/CourseRepository.java
@@ -4,6 +4,10 @@ import com.multi.travel.course.entity.Course;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 /**
  * Please explain the class!!!
@@ -17,4 +21,11 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     // 추천순 정렬 조회
     Page<Course> findByStatusOrderByRecCountDesc(String status, Pageable pageable);
+
+    @Query("SELECT DISTINCT c FROM Course c " +
+            "LEFT JOIN FETCH c.items i " +
+            "LEFT JOIN FETCH i.category " +
+            "WHERE c.courseId = :courseId")
+    Optional<Course> findByIdWithItemsAndCategory(@Param("courseId") Long courseId);
+
 }

--- a/src/main/java/com/multi/travel/plan/service/PlanService.java
+++ b/src/main/java/com/multi/travel/plan/service/PlanService.java
@@ -89,22 +89,22 @@ public class PlanService {
                         .orderNo(item.getOrderNo())
                         .dayNo(item.getDayNo());
 
-                if ("TOUR_SPOT".equals(categoryCode)) {
+                if ("tsp".equals(categoryCode)) {
                     tourSpotApiRepository.findById(item.getPlaceId())
                             .ifPresent(spot -> builder
                                     .title(spot.getTitle())
                                     .address(spot.getAddress())
                                     .mapx(spot.getMapx().toPlainString())
                                     .mapy(spot.getMapy().toPlainString())
-                                    );
-                } else if ("ACCOMMODATION".equals(categoryCode)) {
+                            );
+                } else if ("acc".equals(categoryCode)) {
                     accRepository.findById(item.getPlaceId())
                             .ifPresent(acc -> builder
                                     .title(acc.getTitle())
                                     .address(acc.getAddress())
                                     .mapx(acc.getMapx().toPlainString())
                                     .mapy(acc.getMapy().toPlainString())
-                                    );
+                            );
                 }
 
                 coursePlaceDtos.add(builder.build());

--- a/src/main/resources/templates/ai/course-feedback.html
+++ b/src/main/resources/templates/ai/course-feedback.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>AI 코스 피드백</title>
+  <style>
+    body { font-family: Pretendard, sans-serif; margin: 0; padding: 40px; text-align: center; }
+    textarea { width: 60%; height: 200px; padding: 15px; font-size: 16px; border-radius: 10px; border: 1px solid #ccc; resize: none; }
+    button { margin-top: 30px; padding: 10px 30px; border: none; border-radius: 10px; cursor: pointer; }
+    .btn-primary { background-color: #4b73ff; color: #fff; }
+    .btn-secondary { background-color: #ccc; color: #333; margin-left: 10px; }
+  </style>
+</head>
+<body>
+<h2>AI 추천 코스에 대한 피드백을 입력해주세요 📝</h2>
+<p>예: "숙소가 너무 멀어요", "2일차 관광지 순서를 바꿔주세요"</p>
+
+<form id="feedbackForm">
+  <textarea id="feedbackText" placeholder="피드백을 입력하세요..."></textarea><br>
+  <button type="button" class="btn-primary" onclick="submitFeedback()">피드백 전송</button>
+  <button type="button" class="btn-secondary" onclick="goBack()">취소</button>
+</form>
+
+<script th:inline="javascript">
+  const planId = [[${planId}]];
+
+  function submitFeedback() {
+    const feedback = document.getElementById("feedbackText").value.trim();
+    if (!feedback) {
+      alert("피드백을 입력해주세요.");
+      return;
+    }
+
+    fetch("/ai/courses/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ planId: planId, feedback: feedback })
+    })
+            .then(res => res.json())
+            .then(data => {
+              if (data.status === 200) {
+                alert("피드백이 반영된 코스가 재생성되었습니다!");
+                window.location.href = `/ai/courses/view/${planId}`;
+              } else {
+                alert("코스 재생성 중 오류가 발생했습니다.");
+              }
+            });
+  }
+
+  function goBack() {
+    window.location.href = `/ai/courses/view/${planId}`;
+  }
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/ai/course-view.html
+++ b/src/main/resources/templates/ai/course-view.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>AI 여행 코스 결과</title>
+  <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=YOUR_KAKAO_APP_KEY"></script>
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
+  <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+  <style>
+    body { font-family: Pretendard, sans-serif; margin: 0; padding: 0; background: #f5f6f8; }
+    .container { display: flex; justify-content: center; margin-top: 50px; }
+    .map-area {
+      width: 600px;
+      height: 500px;
+      border-radius: 20px;
+      overflow: hidden;
+      box-shadow: 0 0 8px rgba(0,0,0,0.15);
+      background: white;
+    }
+    .list-area {
+      width: 320px;
+      height: 500px;
+      margin-left: 30px;
+      background: #fff;
+      border-radius: 20px;
+      padding: 15px;
+      overflow-y: auto;
+      box-shadow: 0 0 8px rgba(0,0,0,0.1);
+    }
+    .day-title {
+      font-weight: bold;
+      margin: 15px 0 5px 5px;
+      color: #4b73ff;
+    }
+    .item {
+      background: #f9f9f9;
+      border-radius: 10px;
+      padding: 10px 15px;
+      margin: 5px 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      cursor: grab;
+      transition: all 0.2s ease;
+    }
+    .item:hover { background: #f0f2ff; }
+    .delete-btn {
+      display: none;
+      color: red;
+      font-size: 14px;
+      cursor: pointer;
+    }
+    .item:hover .delete-btn { display: inline; }
+
+    .buttons { text-align: center; margin-top: 40px; }
+    button {
+      margin: 0 10px;
+      padding: 10px 25px;
+      border: none;
+      border-radius: 10px;
+      font-size: 16px;
+      cursor: pointer;
+    }
+    .btn-primary { background: #4b73ff; color: white; }
+    .btn-secondary { background: #ccc; color: #333; }
+
+    h2 { text-align: center; margin-top: 30px; color: #333; }
+  </style>
+</head>
+<body>
+<h2>AI 추천 여행 코스 결과</h2>
+
+<div class="container">
+  <div id="map" class="map-area"></div>
+  <div class="list-area">
+    <div id="courseList"></div>
+  </div>
+</div>
+
+<div class="buttons">
+  <button id="retryBtn" class="btn-secondary">코스 다시짜기</button>
+  <button id="confirmBtn" class="btn-primary">코스 확정하기</button>
+</div>
+
+<script th:inline="javascript">
+  const planId = [[${planId}]];
+
+  let map;
+  let markers = [];
+  let polylines = [];
+
+  $(document).ready(function() {
+    initMap();
+    loadCourse();
+  });
+
+  // Kakao Map 초기화
+  function initMap() {
+    const container = document.getElementById('map');
+    const options = { center: new kakao.maps.LatLng(37.4979, 127.0276), level: 6 };
+    map = new kakao.maps.Map(container, options);
+  }
+
+  // AI 코스 로드
+  function loadCourse() {
+    $.post(`/ai/courses/plan/${planId}`, function(res) {
+      const data = res.data;
+      renderCourseList(data.days);
+      renderMap(data.days);
+    }).fail(() => {
+      alert("AI 코스 데이터를 불러오지 못했습니다.");
+    });
+  }
+
+  // 지도에 마커 및 경로 표시
+  function renderMap(days) {
+    clearMap();
+    const lineCoords = [];
+
+    days.forEach(day => {
+      day.items.forEach((item, idx) => {
+        // 실제 데이터에선 DB 좌표를 불러와야 함 (임시 랜덤 좌표)
+        const lat = 37.4979 + Math.random() * 0.02;
+        const lng = 127.0276 + Math.random() * 0.02;
+        const position = new kakao.maps.LatLng(lat, lng);
+
+        const marker = new kakao.maps.Marker({
+          map: map,
+          position: position,
+          title: `${day.dayNo}일차 ${item.placeType}`
+        });
+        markers.push(marker);
+        lineCoords.push(position);
+      });
+    });
+
+    if (lineCoords.length > 1) {
+      const polyline = new kakao.maps.Polyline({
+        path: lineCoords,
+        strokeWeight: 3,
+        strokeColor: '#4b73ff',
+        strokeOpacity: 0.8
+      });
+      polyline.setMap(map);
+      polylines.push(polyline);
+
+      // 지도 영역 자동 조정
+      const bounds = new kakao.maps.LatLngBounds();
+      lineCoords.forEach(coord => bounds.extend(coord));
+      map.setBounds(bounds);
+    }
+  }
+
+  // 지도 클리어
+  function clearMap() {
+    markers.forEach(m => m.setMap(null));
+    polylines.forEach(p => p.setMap(null));
+    markers = [];
+    polylines = [];
+  }
+
+  // 코스 리스트 렌더링
+  function renderCourseList(days) {
+    const list = $("#courseList").empty();
+
+    days.forEach(day => {
+      const title = $(`<div class="day-title">${day.dayNo}일차</div>`);
+      list.append(title);
+
+      const dayList = $("<div class='day-items'></div>");
+      day.items.forEach((item, idx) => {
+        const div = $(`
+                    <div class="item" data-place-id="${item.placeId}" data-day="${day.dayNo}" data-order="${idx + 1}">
+                        <span>${idx + 1}. ${item.placeType} (${item.placeId})</span>
+                        <span class="delete-btn">삭제</span>
+                    </div>
+                `);
+        dayList.append(div);
+      });
+      list.append(dayList);
+    });
+
+    // 삭제 버튼
+    $(".delete-btn").click(function() {
+      $(this).closest(".item").remove();
+    });
+
+    // 드래그 앤 드롭 (순서 변경)
+    $(".day-items").sortable({
+      update: function(event, ui) {
+        renumberItems();
+      }
+    });
+  }
+
+  // 순서 다시 번호 매기기
+  function renumberItems() {
+    $(".day-items").each(function() {
+      $(this).find(".item").each(function(idx) {
+        $(this).attr("data-order", idx + 1);
+        $(this).find("span:first").text(`${idx + 1}. ${$(this).data("place-id")}`);
+      });
+    });
+  }
+
+  // 코스 다시짜기 (피드백 페이지 이동)
+  $("#retryBtn").click(function() {
+    window.location.href = `/ai/courses/feedback/${planId}`;
+  });
+
+  // 코스 확정하기 (수정 페이지로 이동)
+  $("#confirmBtn").click(function() {
+    window.location.href = `/courses/edit/${planId}`;
+  });
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/course/course-edit.html
+++ b/src/main/resources/templates/course/course-edit.html
@@ -1,0 +1,645 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>코스 수정</title>
+  <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=9be895ba7d6b98f83597991def648c2c"></script>
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
+  <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+  <style>
+    body {
+      font-family: Pretendard, sans-serif;
+      background: #f5f6f8;
+      margin: 0;
+      padding: 0;
+    }
+
+    .page-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: #ddd;
+      padding: 15px 40px;
+    }
+    .page-header h1 { font-size: 20px; margin: 0; }
+    .page-header nav a { margin-left: 15px; color: #333; text-decoration: none; }
+
+    .content-wrapper {
+      width: 1200px;
+      margin: 30px auto;
+      background: #fff;
+      border-radius: 20px;
+      padding: 20px;
+      box-shadow: 0 0 10px rgba(0,0,0,0.1);
+      transition: width 0.3s ease;
+    }
+
+    .plan-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-bottom: 15px;
+    }
+    .plan-header input {
+      font-size: 16px;
+      padding: 5px 10px;
+      border-radius: 8px;
+      border: 1px solid #ccc;
+    }
+
+    .main-area {
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: nowrap;
+      gap: 15px;
+    }
+
+    .left-panel, .right-panel, .map-panel {
+      border-radius: 15px;
+      background: #fafafa;
+      padding: 15px;
+      box-shadow: 0 0 8px rgba(0,0,0,0.1);
+    }
+
+    /* 너비 확장 및 균형 조정 */
+    .left-panel {
+      width: 320px;
+      height: 550px;
+      display: flex;
+      flex-direction: column;
+    }
+    .map-panel {
+      width: 520px;
+      height: 550px;
+    }
+    .right-panel {
+      width: 280px;
+      height: 550px;
+      overflow-y: auto;
+    }
+
+    #placeList { flex: 1; overflow-y: auto; }
+    #pagination { flex-shrink: 0; margin-top: 10px; text-align: center; }
+
+    /* 검색창 */
+    .search-box { display: flex; margin-bottom: 10px; }
+    .search-box input {
+      flex: 1;
+      padding: 5px;
+      border-radius: 8px;
+      border: 1px solid #ccc;
+    }
+
+    /* 탭 버튼 */
+    .tab-menu button {
+      margin: 5px 3px;
+      padding: 5px 10px;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      background: #ccc;
+    }
+    .tab-menu button.active { background: #000; color: #fff; }
+
+    /* 관광지 목록 아이템 */
+    .place-item {
+      background: #fff;
+      border-radius: 10px;
+      margin: 5px 0;
+      padding: 8px 10px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      cursor: pointer;
+    }
+    .place-item:hover { background: #eef2ff; }
+
+    /* 일차 탭 */
+    .day-tabs { display: flex; justify-content: center; margin-bottom: 10px; flex-wrap: wrap; }
+    .day-tabs button {
+      border: none;
+      border-radius: 8px;
+      padding: 5px 10px;
+      margin: 3px;
+      cursor: pointer;
+    }
+    .day-tabs button.active { background: #000; color: white; }
+
+    /* 코스 리스트 */
+    .course-item {
+      background: #fff;
+      border-radius: 10px;
+      padding: 8px 10px;
+      margin: 5px 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      cursor: grab;
+    }
+    .course-item:hover { background: #eef2ff; }
+    .delete-btn { display: none; color: red; cursor: pointer; font-size: 14px; }
+    .course-item:hover .delete-btn { display: inline; }
+
+    /* 버튼 영역 */
+    .button-area {
+      text-align: center;
+      margin-top: 20px;
+    }
+    .button-area button {
+      border: none;
+      border-radius: 10px;
+      padding: 10px 25px;
+      cursor: pointer;
+      font-size: 16px;
+      margin: 0 5px;
+    }
+    .btn-primary { background: #000; color: #fff; }
+    .btn-secondary { background: #ccc; color: #333; }
+
+    /* 페이지네이션 (줄바꿈 방지 + 정렬 고정) */
+    #pagination {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      white-space: nowrap;
+      margin-top: 10px;
+      gap: 4px;
+      overflow-x: auto;
+      scrollbar-width: none;
+    }
+    #pagination::-webkit-scrollbar { display: none; }
+
+    #pagination button {
+      border: none;
+      background: transparent;
+      color: #333;
+      padding: 4px 8px;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: 0.2s;
+      flex-shrink: 0;
+    }
+    #pagination button:hover { background: #eee; }
+    #pagination button.active { background: #000; color: #fff; font-weight: bold; }
+    #pagination button.disabled { color: #ccc; cursor: default; }
+
+    /* 반응형 (중간 화면: 노트북) */
+    @media (max-width: 1200px) {
+      .content-wrapper {
+        width: 95%;
+        padding: 15px;
+      }
+      .main-area {
+        gap: 10px;
+      }
+      .left-panel { width: 280px; }
+      .map-panel { width: 480px; }
+      .right-panel { width: 250px; }
+    }
+
+    /* 반응형 (태블릿: 세로로 스택 정렬) */
+    @media (max-width: 900px) {
+      .main-area {
+        flex-direction: column;
+        align-items: center;
+      }
+      .left-panel, .map-panel, .right-panel {
+        width: 100%;
+        height: auto;
+        max-height: 500px;
+      }
+      .map-panel {
+        order: -1; /* 지도를 위로 */
+        height: 400px;
+      }
+      #pagination { justify-content: center; }
+    }
+
+    /* 반응형 (모바일: 폰 뷰) */
+    @media (max-width: 600px) {
+      .page-header { flex-direction: column; text-align: center; padding: 10px 20px; }
+      .plan-header { flex-direction: column; align-items: flex-start; }
+      .content-wrapper { width: 95%; padding: 10px; }
+      .map-panel { height: 300px; }
+      .left-panel, .right-panel { width: 100%; }
+      .button-area button {
+        width: 48%;
+        font-size: 14px;
+        padding: 8px 0;
+      }
+    }
+  </style>
+</head>
+<body>
+
+<div class="page-header">
+  <h1>TRAVEL PLANNING</h1>
+  <nav>
+    <span>{사용자} 님 환영합니다.</span>
+    <a href="/">Home</a>
+    <a href="/mypage">마이페이지</a>
+    <a href="/logout">로그아웃</a>
+  </nav>
+</div>
+
+<div class="content-wrapper">
+  <div class="plan-header">
+    <input type="text" id="title" placeholder="여행 제목">
+    <div>
+      <input type="date" id="startDate"> ~ <input type="date" id="endDate">
+      <input type="number" id="numberOfPeople" style="width: 60px;"> 명
+    </div>
+  </div>
+
+  <div class="main-area">
+    <!-- 좌측: 관광지/숙소 -->
+    <div class="left-panel">
+      <div class="tab-menu">
+        <button id="tab-tour" class="active">관광지</button>
+        <button id="tab-acc">숙소</button>
+      </div>
+      <div class="search-box">
+        <input type="text" id="searchInput" placeholder="검색어 입력...">
+      </div>
+      <div id="placeList"></div>
+      <div id="pagination"></div>
+    </div>
+
+    <!-- 중앙 지도 -->
+    <div id="map" class="map-panel"></div>
+
+    <!-- 우측 코스 리스트 -->
+    <div class="right-panel">
+      <div class="day-tabs" id="dayTabs"></div>
+      <div id="courseList"></div>
+    </div>
+  </div>
+
+  <div class="button-area">
+    <button id="cancelBtn" class="btn-secondary">수정취소</button>
+    <button id="saveBtn" class="btn-primary">수정완료</button>
+  </div>
+</div>
+
+<script th:inline="javascript">
+  const planId = [[${planId}]];
+  let map, markers = [], polylines = [];
+  let days = [];
+  let activeDay = 1;
+
+  let currentPage = 0;
+  const pageSize = 10;
+  let totalCount = 12935; // 기본은 관광지 기준
+  let lastType = "tour";
+
+  $(document).ready(function() {
+    initMap();
+    loadPlan();
+    setupTabs();
+    setupSearch();
+  });
+
+  function initMap() {
+    const container = document.getElementById('map');
+    const options = { center: new kakao.maps.LatLng(37.4979, 127.0276), level: 6 };
+    map = new kakao.maps.Map(container, options);
+  }
+
+  function loadPlan() {
+    $.get(`/plans/${planId}`, function(res) {
+      const plan = res.data;
+      $("#title").val(plan.title);
+      $("#numberOfPeople").val(plan.numberOfPeople);
+      $("#startDate").val(plan.startDate);
+      $("#endDate").val(plan.endDate);
+
+      const dayCount = dayDiff(plan.startDate, plan.endDate);
+      days = Array.from({ length: dayCount }, (_, i) => ({ dayNo: i + 1, items: [] }));
+
+      if (plan.coursePlaces?.length) {
+        plan.coursePlaces.forEach(p => {
+          const day = days.find(d => d.dayNo === p.dayNo);
+          if (day) day.items.push(p);
+        });
+      }
+
+      renderDayTabs(dayCount);
+      renderCourseList();
+      renderMap();
+      loadPlaces("tour", "", 0);
+    });
+  }
+
+  function dayDiff(start, end) {
+    const s = new Date(start);
+    const e = new Date(end);
+    return Math.ceil((e - s) / (1000 * 60 * 60 * 24)) + 1;
+  }
+
+  function renderDayTabs(count) {
+    const tabs = $("#dayTabs").empty();
+    for (let i = 1; i <= count; i++) {
+      const btn = $(`<button class="${i === 1 ? "active" : ""}">${i}일차</button>`);
+      btn.click(() => { activeDay = i; $(".day-tabs button").removeClass("active"); btn.addClass("active"); renderCourseList(); renderMap();  });
+      tabs.append(btn);
+    }
+  }
+
+  function renderCourseList() {
+    const list = $("#courseList").empty();
+    const currentDay = days.find(d => d.dayNo === activeDay);
+
+    // 번호 없이 장소명만 표시
+    currentDay.items
+            .sort((a, b) => a.orderNo - b.orderNo)
+            .forEach((item, idx) => {
+              const div = $(`
+        <div class="course-item" data-idx="${idx}">
+          <span>${item.title}</span>
+          <span class="delete-btn">삭제</span>
+        </div>
+      `);
+              list.append(div);
+            });
+
+    // 삭제 시 즉시 지도 반영
+    $(".delete-btn").click(function() {
+      const idx = $(this).closest(".course-item").data("idx");
+      currentDay.items.splice(idx, 1);
+      renderCourseList();
+      renderMap();
+    });
+
+    // 드래그 후 지도 즉시 갱신
+    $("#courseList").sortable({
+      update: function () {
+        const newItems = [];
+        $("#courseList .course-item").each(function (idx) {
+          const i = $(this).data("idx");
+          newItems.push(currentDay.items[i]);
+        });
+        // 순서 반영
+        currentDay.items = newItems.map((it, idx) => ({ ...it, orderNo: idx + 1 }));
+        renderCourseList();
+        renderMap(); // 즉시 갱신
+      }
+    });
+
+  }
+
+  // 모든 일차 코스를 지도에 표시 (현재 일차는 검정색, 나머지는 회색)
+  function renderMap() {
+    clearMap();
+    const bounds = new kakao.maps.LatLngBounds();
+
+    days.forEach(day => {
+      const coords = [];
+
+      day.items.forEach(item => {
+        const lat = parseFloat(item.mapy);
+        const lng = parseFloat(item.mapx);
+        if (!isNaN(lat) && !isNaN(lng)) {
+          const pos = new kakao.maps.LatLng(lat, lng);
+          coords.push(pos);
+
+          // 마커 색상 구분 (현재 일차는 파란색, 나머지는 회색)
+          const markerImage = new kakao.maps.MarkerImage(
+                  day.dayNo === activeDay
+                          ? "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png" // 파란 마커
+                          : "https://t1.daumcdn.net/mapjsapi/images/marker.png", // 회색 기본 마커
+                  new kakao.maps.Size(24, 35)
+          );
+
+          const marker = new kakao.maps.Marker({
+            map,
+            position: pos,
+            title: `[${day.dayNo}일차] ${item.title}`,
+            image: markerImage
+          });
+          markers.push(marker);
+          bounds.extend(pos);
+        }
+      });
+
+      // 선 색상 구분
+      if (coords.length > 1) {
+        const color = day.dayNo === activeDay ? "#000000" : "#a0a0a0";
+        const polyline = new kakao.maps.Polyline({
+          path: coords,
+          strokeWeight: day.dayNo === activeDay ? 4 : 2,
+          strokeColor: color,
+          strokeOpacity: 0.9
+        });
+        polyline.setMap(map);
+        polylines.push(polyline);
+      }
+    });
+
+    // 지도 중심 자동 맞춤
+    if (!bounds.isEmpty()) {
+      map.setBounds(bounds);
+    } else {
+      map.setCenter(new kakao.maps.LatLng(37.4979, 127.0276));
+      map.setLevel(6);
+    }
+  }
+
+
+  function clearMap() {
+    markers.forEach(m => m.setMap(null));
+    polylines.forEach(p => p.setMap(null));
+    markers = [];
+    polylines = [];
+  }
+
+
+  // 관광지/숙소 목록 + 페이지네이션
+  function loadPlaces(type, keyword = "", page = 0) {
+    lastType = type;
+    currentPage = page;
+    $("#placeList").empty();
+
+    totalCount = type === "tour" ? 12935 : 3549;
+
+    let url =
+            type === "tour"
+                    ? (keyword
+                            ? `/spots/search?keyword=${keyword}&page=${page}&size=${pageSize}`
+                            : `/spots/list?page=${page}&size=${pageSize}`)
+                    : (keyword
+                            ? `/accommodations/search?keyword=${keyword}&page=${page}&size=${pageSize}`
+                            : `/accommodations/list?page=${page}&size=${pageSize}`);
+
+    $.get(url, function (res) {
+      const places = res.data || [];
+      // type 값이 불분명할 때 대비
+      let code = "tsp";
+      if (type === "acc") code = "acc";
+      else if (type === "tour") code = "tsp";
+      else console.warn("알 수 없는 type 감지:", type);
+
+      places.forEach((p) => {
+        // id 검증 및 숫자 변환
+        const placeId = Number(p.id);
+        if (!placeId) {
+          console.warn("유효하지 않은 ID 감지:", p);
+          return;
+        }
+
+        const div = $(`
+        <div class="place-item"
+             data-type="${code}"
+             data-id="${placeId}"
+             data-mapx="${p.mapx}"
+             data-mapy="${p.mapy}">
+          <span>${p.title}</span><span>+</span>
+        </div>
+      `);
+
+        // 클릭 이벤트: 강제 숫자 변환
+        div.click(() =>
+                addToCourse(placeId, p.title, code, parseFloat(p.mapx), parseFloat(p.mapy))
+        );
+
+        $("#placeList").append(div);
+      });
+
+      renderPagination();
+    });
+  }
+
+
+  function renderPagination() {
+    const $pagination = $("#pagination").empty();
+    const totalPages = Math.ceil(totalCount / pageSize);
+    const maxVisible = 5;
+    const half = Math.floor(maxVisible / 2);
+    let start = Math.max(0, currentPage - half);
+    let end = Math.min(totalPages - 1, start + maxVisible - 1);
+
+    if (end - start < maxVisible - 1) start = Math.max(0, end - maxVisible + 1);
+
+    // 이전
+    const prevBtn = $("<button>&laquo; 이전</button>");
+    if (currentPage === 0) prevBtn.addClass("disabled");
+    else prevBtn.click(() => loadPlaces(lastType, $("#searchInput").val().trim(), currentPage - 1));
+    $pagination.append(prevBtn);
+
+    // 숫자 버튼
+    for (let i = start; i <= end; i++) {
+      const btn = $(`<button>${i + 1}</button>`);
+      if (i === currentPage) btn.addClass("active");
+      btn.click(() => loadPlaces(lastType, $("#searchInput").val().trim(), i));
+      $pagination.append(btn);
+    }
+
+    // 다음
+    const nextBtn = $("<button>다음 &raquo;</button>");
+    if (currentPage >= totalPages - 1) nextBtn.addClass("disabled");
+    else nextBtn.click(() => loadPlaces(lastType, $("#searchInput").val().trim(), currentPage + 1));
+    $pagination.append(nextBtn);
+  }
+
+  function setupSearch() {
+    $("#searchInput").on("keyup", function() {
+      const keyword = $(this).val().trim();
+      const isTour = $("#tab-tour").hasClass("active");
+      loadPlaces(isTour ? "tour" : "acc", keyword, 0);
+    });
+  }
+
+  function addToCourse(id, title, code, mapx, mapy) {
+    const currentDay = days.find(d => d.dayNo === activeDay);
+
+    // code가 undefined/null이면 기본값 "tsp" 부여
+    const safeCode = code || (lastType === "acc" ? "acc" : "tsp");
+
+    currentDay.items.push({
+      id,
+      title,
+      categoryCode: safeCode, // 항상 null 방지
+      orderNo: currentDay.items.length + 1,
+      dayNo: activeDay,
+      mapx: mapx,
+      mapy: mapy
+    });
+
+    renderCourseList();
+    renderMap();
+  }
+
+
+  function setupTabs() {
+    $("#tab-tour").click(() => {
+      $(".tab-menu button").removeClass("active");
+      $("#tab-tour").addClass("active");
+      loadPlaces("tour", "", 0);
+    });
+    $("#tab-acc").click(() => {
+      $(".tab-menu button").removeClass("active");
+      $("#tab-acc").addClass("active");
+      loadPlaces("acc", "", 0);
+    });
+  }
+
+  // 수정완료 버튼
+  $("#saveBtn").click(function () {
+    if (!confirm("코스 수정을 저장하시겠습니까?")) return;
+
+    // null 또는 undefined id 확인
+    const invalid = days.some(day =>
+            day.items.some(item => !item.id)
+    );
+    if (invalid) {
+      alert("저장할 수 없는 항목이 있습니다. (장소 ID가 누락됨)");
+      console.error(days);
+      return;
+    }
+
+    const req = {
+      planId: planId,
+      items: days.flatMap(day =>
+              day.items.map((item, idx) => ({
+                placeId: item.id,
+                categoryCode: item.categoryCode || (item.type === "ACCOMMODATION" ? "acc" : "tsp"), // ✅ 기본값 보정
+                orderNo: idx + 1,
+                dayNo: day.dayNo
+              }))
+      )
+    };
+
+
+    $.ajax({
+      url: `/courses/${planId}`,
+      type: "PUT",
+      contentType: "application/json",
+      data: JSON.stringify(req),
+      success: () => {
+        alert("코스 수정이 완료되었습니다!");
+        window.location.href = `/plans/${planId}`;
+      },
+      error: (xhr) => {
+        console.error(xhr.responseText);
+        alert("코스 수정 중 오류가 발생했습니다.\n잠시 후 다시 시도해주세요.");
+      }
+    });
+  });
+
+
+  // 수정취소 버튼
+  $("#cancelBtn").click(function() {
+    if (confirm("정말 수정 내용을 취소하시겠습니까?")) {
+      if (planId) {
+        window.location.href = `/plans/${planId}`;
+      } else {
+        window.location.href = `/plans`; // planId가 없을 경우 목록 페이지로
+      }
+    }
+  });
+
+</script>
+</body>
+</html>

--- a/src/test/java/com/multi/travel/course/service/CourseServiceTest.java
+++ b/src/test/java/com/multi/travel/course/service/CourseServiceTest.java
@@ -1,28 +1,18 @@
 package com.multi.travel.course.service;
 
-import com.multi.travel.course.dto.CourseItemReqDto;
-import com.multi.travel.course.dto.CourseReqDto;
-import com.multi.travel.course.dto.CourseResDto;
-import com.multi.travel.course.entity.Course;
-import com.multi.travel.plan.entity.TripPlan;
 import com.multi.travel.course.repository.CourseRepository;
+import com.multi.travel.plan.entity.TripPlan;
 import com.multi.travel.plan.repository.TripPlanRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-
-import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.when;
 
 /**
  * Please explain the class!!!
@@ -59,8 +49,8 @@ class CourseServiceTest {
                 .thenReturn(Optional.of(mockPlan));
 
         // 요청 DTO
-        CourseItemReqDto item1 = new CourseItemReqDto("TOUR_SPOT", 1L, 1);
-        CourseItemReqDto item2 = new CourseItemReqDto("ACCOMMODATION", 2L, 2);
+//        CourseItemReqDto item1 = new CourseItemReqDto("TOUR_SPOT", 1L, 1);
+//        CourseItemReqDto item2 = new CourseItemReqDto("ACCOMMODATION", 2L, 2);
 //        CourseReqDto dto = new CourseReqDto(planId, List.of(item1, item2));
 
         // when


### PR DESCRIPTION
## 📎 관련 이슈
Closes #87 


## 📝 작업 내용
- 관광지/숙소 탭 전환
- 페이지 하단에서 페이지별 이동
- 검색 기능
- 코스 아이템 추가/삭제/순서 변경
- 수정/취소 시 DB 반영 및 이동
- 카카오맵 연동

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 💬 비고
